### PR TITLE
Remove clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,15 +8,17 @@
 
   :pedantic? :abort
 
-  :parent-project {:coords [org.openvoxproject/clj-parent "7.6.3"]
-                   :inherit [:managed-dependencies]}
+  ;; These are to enforce consistent versions across dependencies of dependencies,
+  ;; and to avoid having to define versions in multiple places. If a component
+  ;; defined under :dependencies ends up causing an error due to :pedantic? :abort,
+  ;; because it is a dep of a dep with a different version, move it here.
+  :managed-dependencies [[org.clojure/clojure "1.12.4"]
+                         [ring/ring-codec "1.1.2"]]
 
   :dependencies [[org.clojure/clojure]
-                 [prismatic/schema]
-                 [org.openvoxproject/trapperkeeper-metrics]
-                 [org.openvoxproject/comidi]]
-
-  :plugins [[lein-parent "0.3.9"]]
+                 [prismatic/schema "1.1.12"]
+                 [org.openvoxproject/trapperkeeper-metrics "2.1.0"]
+                 [org.openvoxproject/comidi "1.1.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/CLOJARS_USERNAME
@@ -24,12 +26,12 @@
                                      :sign-releases false}]]
 
   :profiles {:dev {:source-paths ["dev"]
-                   :dependencies [[org.openvoxproject/trapperkeeper :classifier "test"]
-                                  [org.openvoxproject/kitchensink :classifier "test"]
-                                  [org.openvoxproject/trapperkeeper-status]
-                                  [org.openvoxproject/http-client]
-                                  [org.bouncycastle/bcpkix-jdk18on]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10]]}}
+                   :dependencies [[org.openvoxproject/trapperkeeper "4.3.0":classifier "test"]
+                                  [org.openvoxproject/kitchensink "3.5.3" :classifier "test"]
+                                  [org.openvoxproject/trapperkeeper-status "1.3.0"]
+                                  [org.openvoxproject/http-client "2.2.0"]
+                                  [org.bouncycastle/bcpkix-jdk18on "1.83"]
+                                  [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.0"]]}}
 
   :aliases {"example" ["run" "-m" "example.comidi-metrics-web-app"]
             "example-data" ["run" "-m" "example.traffic-generator"]})


### PR DESCRIPTION
In an effort to simplify our projects, this removes clj-parent and specifies dependency versions directly. Since we only have two top-level components (openvox-server and openvoxdb) and we use renovate to keep dependencies up to date, this introduces less churn and coordination when dependencies need updating.