### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/dev/example/bootstrap.cfg
+++ b/dev/example/bootstrap.cfg
@@ -1,6 +1,6 @@
 example.comidi-metrics-web-app/example-web-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.openvoxproject/trapperkeeper-comidi-metrics "1.0.8-SNAPSHOT"
+(defproject org.openvoxproject/trapperkeeper-comidi-metrics "1.1.0-SNAPSHOT"
   :description "Comidi/HTTP Metrics for Trapperkeeper"
   :url "http://github.com/openvoxproject/trapperkeeper-comidi-metrics"
   :license {:name "Apache-2.0"
@@ -29,9 +29,9 @@
                          [org.openvoxproject/kitchensink "3.5.7" :classifier "test"]
                          [org.openvoxproject/trapperkeeper "4.3.5"]
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test"]
-                         [org.openvoxproject/trapperkeeper-metrics "2.1.9"]
-                         [org.openvoxproject/trapperkeeper-status "1.3.4"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]
+                         [org.openvoxproject/trapperkeeper-metrics "2.2.0"]
+                         [org.openvoxproject/trapperkeeper-status "1.4.0"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]
                          [org.ring-clojure/ring-core-protocols "1.14.2"]
                          [org.ring-clojure/ring-websocket-protocols "1.14.2"]
                          [org.slf4j/slf4j-api "2.0.17"]
@@ -55,7 +55,7 @@
                                   [org.openvoxproject/kitchensink :classifier "test"]
                                   [org.openvoxproject/trapperkeeper :classifier "test"]
                                   [org.openvoxproject/trapperkeeper-status]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10]]}}
+                                  [org.openvoxproject/trapperkeeper-webserver]]}}
 
   :aliases {"example" ["run" "-m" "example.comidi-metrics-web-app"]
             "example-data" ["run" "-m" "example.traffic-generator"]})


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
